### PR TITLE
add option to create a new page from a non-existing reference

### DIFF
--- a/document_page_reference/models/document_page.py
+++ b/document_page_reference/models/document_page.py
@@ -46,6 +46,11 @@ class DocumentPage(models.Model):
 
     _inherit = 'document.page'
 
+    @api.model
+    def default_get(self, fields):
+        rec = super(DocumentPage, self).default_get(fields)
+        return rec
+
     reference = fields.Char(
         help="Used to find the document, it can contain letters, numbers and _"
     )
@@ -74,21 +79,25 @@ class DocumentPage(models.Model):
         document = self.search([('reference', '=', code)])
         if document:
             return document
-        return False
+        else:
+            return self.env[self._name]
 
     def get_reference(self, code):
         element = self._get_document(code)
-        if not element:
-            return code
         if self.env.context.get('raw_reference', False):
             return html_escape(element.display_name)
-        text = '<a href="#" class="oe_direct_line" ' \
-               'name="%s" data-id="%s">%s</a>'
-        return text % (
+        text = """<a href="#" class="oe_direct_line"
+        data-oe-model="%s" data-oe-id="%s" name="%s">%s</a>
+        """
+        if not element:
+            text = '<i>%s</i>' % text
+        res = text % (
             element._name,
-            element.id,
-            html_escape(element.display_name)
+            element and element.id or '',
+            code,
+            html_escape(element.display_name or code),
         )
+        return res
 
     def _get_template_variables(self):
         return {'ref': self.get_reference}

--- a/document_page_reference/static/src/js/editor.js
+++ b/document_page_reference/static/src/js/editor.js
@@ -14,11 +14,18 @@ odoo.define('document_page_reference.backend', function (require) {
             event.preventDefault();
             event.stopPropagation();
             var element = $(event.target).closest('.oe_direct_line')[0];
+            var default_reference = element.name;
+            var model = $(event.target).data('oe-model');
+            var id = $(event.target).data('oe-id');
+            var context = this.record.getContext(this.recordParams);
+            if (default_reference){
+                context['default_reference'] = default_reference
+            }
             this._rpc({
-                model: element.name,
+                model: model,
                 method: 'get_formview_action',
-                args: [[parseInt(element.dataset.id)]],
-                context: this.record.getContext(this.recordParams),
+                args: [[parseInt(id)]],
+                context: context,
             })
             .then(function (action) {
                 self.trigger_up('do_action', {action: action});


### PR DESCRIPTION
When you enter a page reference in an existing wiki and it does not exist, it appears in italic. When you press the link it creates a new page.
![image](https://user-images.githubusercontent.com/7683926/69872378-88b27a00-12b5-11ea-88fc-0f5afcf09885.png)
